### PR TITLE
Fix dragging item to same index

### DIFF
--- a/src/FlashDragList.tsx
+++ b/src/FlashDragList.tsx
@@ -106,9 +106,7 @@ const FlashDragList: FunctionComponent<Props> = (props) => {
       setActive(false);
       fromIndexRef.current = fromIndex;
       toIndexRef.current = toIndex;
-      if(changed) {
-        setCallOnSort(true);
-      }
+      setCallOnSort(true);
     }, endAnimationDuration + 1)
   };
   


### PR DESCRIPTION
For some reason when dragging an item to its fromIndex, if the sort function isn't run, I see a crash if I then try and delete that same item in my application. I haven't looked into the issue closely, I just observed that running the sort function in this scenario fixes the crash so thought others might've the same issue.